### PR TITLE
ci: updated ci

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Changes
+
+<!-- Describe changes here. Attach screenshots/video if changes affect UI. -->
+<!-- If PR is not ready for review yet, make it draft. -->
+<!-- Add tests if it makes sense, especially if it's a bug fix. -->
+
+## Related issues
+
+Fixes #___
+
+## Checklist
+
+- [ ] PR is ready for review (if not, it should be a draft).
+- [ ] PR title follows [Conventional Commits][1] guidelines.
+- [ ] Screenshots/video added.
+- [ ] Tests added.
+- [ ] Self-review done.
+
+[1]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/.github/workflows/pr_watcher.yml
+++ b/.github/workflows/pr_watcher.yml
@@ -1,0 +1,34 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            style
+            test
+          requireScope: false
+          validateSingleCommit: false


### PR DESCRIPTION
## Changes

- added pr lint watcher for semantic versioning
- added pr template

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/